### PR TITLE
fix(webservice): Downgrade Spring

### DIFF
--- a/tilt-webservice/build.gradle.kts
+++ b/tilt-webservice/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
     war
-    id("org.springframework.boot") version "3.3.4"
+    id("org.springframework.boot") version "2.7.8"
     id("io.spring.dependency-management") version "1.1.6"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
 }
@@ -40,11 +40,11 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:0.55.+")
     implementation("org.jetbrains.exposed:exposed-java-time:0.55.+")
     implementation("org.jetbrains.exposed:exposed-spring-boot-starter:0.55.+")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.6.0")
+    implementation("org.springdoc:springdoc-openapi-ui:1.8.0")
 
     runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
-    runtimeOnly("org.xerial:sqlite-jdbc")
+    developmentOnly("org.xerial:sqlite-jdbc")
+    developmentOnly("org.springframework.boot:spring-boot-starter-tomcat")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/tilt-webservice/src/main/kotlin/org/heathtech/tilt/webserver/ServletInitializer.kt
+++ b/tilt-webservice/src/main/kotlin/org/heathtech/tilt/webserver/ServletInitializer.kt
@@ -1,9 +1,0 @@
-package org.heathtech.tilt.webserver
-
-import org.springframework.boot.builder.SpringApplicationBuilder
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
-
-class ServletInitializer : SpringBootServletInitializer() {
-    override fun configure(application: SpringApplicationBuilder): SpringApplicationBuilder =
-        application.sources(TiltWebserverApplication::class.java)
-}

--- a/tilt-webservice/src/main/kotlin/org/heathtech/tilt/webserver/TiltWebserverApplication.kt
+++ b/tilt-webservice/src/main/kotlin/org/heathtech/tilt/webserver/TiltWebserverApplication.kt
@@ -1,10 +1,15 @@
 package org.heathtech.tilt.webserver
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.runApplication
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 
 @SpringBootApplication
-class TiltWebserverApplication
+class TiltWebserverApplication : SpringBootServletInitializer() {
+    override fun configure(application: SpringApplicationBuilder): SpringApplicationBuilder =
+        application.sources(TiltWebserverApplication::class.java)
+}
 
 fun main(args: Array<String>) {
     runApplication<TiltWebserverApplication>(*args)


### PR DESCRIPTION
As much as I would like to use the latest and greatest, it turns out the server we deploy to is limited to Tomcat 9, which means we can't use Spring Boot 3.  It took a long time for me to even identify that the deployment was failing, since Tomcat returns 200 OK and reports a running deployment, even though it can't actually handle the newer code.

This PR downgrades Spring Boot 3/Spring 6 to Spring Boot 2/Spring 5, and updates some dependencies that required the newer Spring.  Additionally, I stripped the embedded dependencies from the .war file to reduce file size, since using the Tomcat manager is pretty slow at bringing in >50 MB.